### PR TITLE
[Bug fix]

### DIFF
--- a/pubmed_crawler.py
+++ b/pubmed_crawler.py
@@ -310,9 +310,10 @@ def find_publications(syn, grant_id, table_id, email):
     if pmids:
         print("Pulling information from publications... ")
         table = pull_info(pmids, grants, email)
+        print(f"  Publications pre-annotated: {len(table.index)}\n")
     else:
         table = pd.DataFrame()
-    print()
+        print()
     return table
 
 

--- a/pubmed_crawler.py
+++ b/pubmed_crawler.py
@@ -245,7 +245,7 @@ def pull_info(pmids, curr_grants, email):
                 if related_grants:
                     center = curr_grants.loc[curr_grants['grantNumber'].isin(
                         related_grants)]
-                    consortium = ", ".join(set(center['consortium']))
+                    consortium = ", ".join(set(center['consortium'].sum()))
                     themes = ", ".join(set(center['theme'].sum()))
                 else:
                     consortium = themes = ""

--- a/pubmed_crawler.py
+++ b/pubmed_crawler.py
@@ -199,7 +199,8 @@ def pull_info(pmids, curr_grants, email):
     with requests.Session() as session:
         for result in results:
             pmid = result.get('pmid')
-            if pmid in pmids:
+            pub_type = result.get('pubTypeList').get('pubType')
+            if pmid in pmids and "Published Erratum" not in pub_type:
 
                 # GENERAL INFO
                 url = f"https://pubmed.ncbi.nlm.nih.gov/{pmid}"


### PR DESCRIPTION
This PR includes multiple fixes, namely:

* ignore Erratums, which do not include an author list (related bug report: #24)
* table schema for Grants recently updated, where `consortium` is now a STRINGLIST instead of a STRING

Additionally: 
STDOUT includes a report on the number of new publications found, but since we are now ignoring Erratums, an additional report has been added to indicate how many are actually included in the manifest, e.g.

```
Querying for grant numbers... 
  Number of grants: 130

Getting PMIDs from NCBI... 
  Total unique publications: 3129

Comparing with table: Portal - Publications Merged...
  New publications found: 85

Pulling information from publications... 
  Publications pre-annotated: 80                   ← this

Generating manifest... 
-- DONE --
```