### PR TITLE
fix: handle `None` author list

### DIFF
--- a/pubmed_crawler.py
+++ b/pubmed_crawler.py
@@ -278,7 +278,7 @@ def pull_info(pmids, curr_grants, email):
                     'Publication Authors': [", ".join(authors)],
                     'Publication Abstract': [abstract],
                     'Publication Assay': [assay],
-                    'Publication TumorType': [tumor_type],
+                    'Publication Tumor Type': [tumor_type],
                     'Publication Tissue': [tissue],
                     'Publication Dataset Alias': [", ".join(dataset_ids)],
                     'Publication Accessibility': [accessbility]

--- a/pubmed_crawler.py
+++ b/pubmed_crawler.py
@@ -210,11 +210,15 @@ def pull_info(pmids, curr_grants, email):
                     'isoabbreviation', journal_info.get('medlineAbbreviation'))
                 year = result.get('pubYear')
                 title = result.get('title').rstrip(".")
-                authors = [
-                    f"{author.get('firstName')} {author.get('lastName')}"
-                    for author
-                    in result.get('authorList').get('author')
-                ]
+                try:
+                    authors = [
+                        f"{author.get('firstName')} {author.get('lastName')}"
+                        for author
+                        in result.get('authorList').get('author')
+                    ]
+                except AttributeError:
+                    # There is not an author list with this publication.
+                    authors = []
                 abstract = result.get('abstractText', "No abstract available.").replace(
                     "<h4>", " ").replace("</h4>", ": ").lstrip()
                 keywords = result.get('keywordList', {}).get('keyword', "")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-synapseclient >= 2.7.0
-pandas >= 1.5.1
+synapseclient >= 3.0.0
+pandas >= 2.1.1
 biopython >= 1.79
 beautifulsoup4 >= 4.11.1
 lxml >= 4.9.1


### PR DESCRIPTION
## Changelog 
* catch `AttributeError` exception when a publication does not have `authorList`
   * defaults list of authors to an empty list
* update colname from `Publication TumorType` to `Publication Tumor Type` ([ref](https://sagebionetworks.slack.com/archives/C049EV977NV/p1692821475255769?thread_ts=1692797952.335009&cid=C049EV977NV))  
* upgrade versions for synapseclient and pandas