### PR TITLE
csv compare script used for filtering out old publications that were …

### DIFF
--- a/compare_csvs.py
+++ b/compare_csvs.py
@@ -1,0 +1,20 @@
+import pandas as pd
+
+# Load the first CSV file into a DataFrame (NEW MANIFEST)
+file1 = './csvs/feb/2025-02-04_publications-manifest-nodec.csv'
+df1 = pd.read_csv(file1)
+
+# Load the second CSV file into another DataFrame
+file2 = './csvs/2025-01-06_publications-manifest.csv'
+df2 = pd.read_csv(file2)
+
+# Identify "Pubmed Id" values from df2 that need to be removed from df1
+pubmed_ids_to_remove = set(df2['Pubmed Id'])
+# Remove rows from df1 that have matching "Pubmed Id" values in df2
+df1 = df1[~df1['Pubmed Id'].isin(pubmed_ids_to_remove)]
+
+# Save the modified DataFrame back to a new CSV file
+output_file = './csvs/feb/2025-02-04_publications-manifest-final.csv'
+df1.to_csv(output_file, index=False)
+
+print(f"Rows with matching Pubmed Id removed. Saved to {output_file}")


### PR DESCRIPTION
Added a manual csv compare script used for filtering out old publications that were previously annotated (used by @aditigopalan and sent to me) Need to generalize and make sure it can be run once instead of on each different old manifest we have, since the pubmed_crawler pulls all publications regardless of when it was created. Should probably create a command line script that allows both pubmed_crawler and compare_csvs (once generalized) to run together and output a manifest with only new publications. Right now this process is very manual.