### PR TITLE
Utilize retry loop for Entrez API calls

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-synapseclient >= 3.0.0
-pandas >= 2.1.1
-biopython >= 1.79
-beautifulsoup4 >= 4.11.1
-lxml >= 4.9.1
-openpyxl >= 3.0.10
+synapseclient >= 4.9.0
+pandas >= 2.3.3
+biopython >= 1.86
+beautifulsoup4 >= 4.14.3
+lxml >= 6.0.2
+openpyxl >= 3.1.5


### PR DESCRIPTION
Fixes #41

## Changelog
* Add handling for `RuntimeServer`, `urllib.error.HTTPError`, and `http.client.IncompleteRead` to better manage network instability with the NCBI server
* Implement a retry loop for failed requests (default: 3 retries, 1-second delay).
   * PMIDs that exceed the maximum retries will now be skipped gracefully rather than crashing the script
* Other general updates, including:
   * Replace deprecated `synapseclient` functions 
   * Update library versions in `requirements.txt`

## Example run

```
$ python pubmed_crawler.py -t syn21868591
Querying for grant numbers... 
  Number of grants: 160

Getting PMIDs from NCBI... 
  Total unique publications: 4886

Comparing with table: Portal - Publications Merged...
  New publications found: 730

Pulling information from publications... 
  Network issue getting related info for 41306346, trying again...
  Network issue getting related info for 41193876, trying again...
  Network issue getting related info for 41193876, trying again...
  ⚠️ Failed to get related info for 41193876. Skipping...
```

> [!NOTE]
> I didn't run the crawler to completion, since I suspect it will take awhile to fetch info from 730 publications.  Also, wanted to check if that count seems correct? Seems higher than usual! @aditya-nath-sage 